### PR TITLE
fix run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "watch-parcel": "parcel watch index.html --out-dir debug --no-hmr",
-    "watch-firefox": "web-ext run --source-dir ./debug/ --firefox=firefoxdeveloperedition --browser-console",
+    "watch-firefox": "web-ext run --source-dir ./debug/ --firefox=firefox-devedition --browser-console",
     "watch-static": "watch \"npm run copy-files\" ./static",
     "copy-files": "copyfiles -a -u 1 \"./static/**/*\" ./debug",
     "build": "parcel build index.html",
@@ -31,7 +31,7 @@
   "bugs": {
     "url": "https://github.com/soapdog/patchfox/issues"
   },
-  "browserlist": [
+  "browserslist": [
     "Firefox ESR"
   ],
   "homepage": "https://github.com/soapdog/patchfox#readme",
@@ -60,6 +60,7 @@
     "copyfiles": "^2.1.0",
     "parcel-bundler": "^1.11.0",
     "sass": "^1.14.1",
-    "watch": "^1.0.2"
+    "watch": "^1.0.2",
+    "web-ext": "^2.9.3"
   }
 }

--- a/src/packages/feedViewer/public.js
+++ b/src/packages/feedViewer/public.js
@@ -2,7 +2,7 @@ import m from "mithril";
 import stream from "mithril/stream";
 import pull from "pull-stream";
 import md from "ssb-markdown";
-import timeago from "timeago.js";
+import { format } from "timeago.js";
 import common from "../common";
 
 var thread = stream([]);
@@ -61,8 +61,6 @@ const Public = {
     }
   },
   publicView: () => {
-    console.log(thread());
-    const timeagoInstance = timeago();
     const threads = thread();
     return threads.map(t => {
       if (t.hasOwnProperty("messages")) {
@@ -72,7 +70,7 @@ const Public = {
               m("div.message-header", [
                 m("div.message-author", Public.avatar(message.value.author)),
                 m("div.space", ""),
-                m("div.message-date", timeagoInstance.format(message.value.timestamp))
+                m("div.message-date", format(message.value.timestamp))
               ]),
               m("div.message-body", Public.mdown(message.value.content.text)),
               m("div.message-footer", [

--- a/src/packages/feedViewer/thread.js
+++ b/src/packages/feedViewer/thread.js
@@ -2,7 +2,7 @@ import m from "mithril";
 import stream from "mithril/stream";
 import pull from "pull-stream";
 import md from "ssb-markdown";
-import timeago from "timeago.js";
+import { format } from "timeago.js";
 import common from "../common";
 
 var thread = stream([]);
@@ -62,8 +62,6 @@ const Thread = {
     }
   },
   threadView: () => {
-    console.log(thread());
-    const timeagoInstance = timeago();
     const threads = thread();
     return threads.map(t => {
       if (t.hasOwnProperty("messages")) {
@@ -73,7 +71,7 @@ const Thread = {
               m("div.message-header", [
                 m("div.message-author", Thread.avatar(message.value.author)),
                 m("div.space", ""),
-                m("div.message-date", timeagoInstance.format(message.value.timestamp))
+                m("div.message-date", format(message.value.timestamp))
               ]),
               m("div.message-body", Thread.mdown(message.value.content.text)),
               m("div.message-footer", [


### PR DESCRIPTION
just three nitpicks that stopped me from using `npm run dev`

* parcel was complaining about the singular `browserlist`
* web-ext was missing from the dev deps (not found error)
* on nixos the binary is called differently (watch-firefox) (This change is debatable of course, just wonder what it is on other platforms, like archlinux or osx)