### PR TITLE
small grammar adjustments for readability

### DIFF
--- a/docs/message_types/about.md
+++ b/docs/message_types/about.md
@@ -1,5 +1,5 @@
 # about
-About messages are used to add additional information to another messages, much like attaching post-it notes to some book page. You're _attaching information about_ something. Most use cases of `about` messages are to add names, images and descriptions to a user profile.
+About messages are used to add additional information to another message, much like attaching post-it notes to some book page. You're _attaching information about_ something. Most use cases of `about` messages are to add names, images and descriptions to a user profile.
 
 > **Attention:** There is no central authority handling names on the Scuttleverse. Much like in the physical world where two people can have the exact same name so it is on Scuttlebutt.
 >
@@ -9,7 +9,7 @@ About messages are used to add additional information to another messages, much 
 
 `about` messages are also used by [ssb-gathering](https://www.npmjs.com/package/ssb-gathering-schema) which is the collection of message types used by Secure Scuttlebutt to support events and gatherings. Patchfox currently doesn't support gatherings.
 
-## How does it look like?
+## What does it look like?
 
 ~~~
 {

--- a/docs/message_types/blog.md
+++ b/docs/message_types/blog.md
@@ -1,14 +1,14 @@
 # blog
 
-Sometimes messages of type `post` are not enough for you to express what you need. All messages in Secure Scuttlebutt have a maximum size of 8k, this is counting the metadata associated with the message and not just the content itself. For those occasions when you need to write longer messages you can use `blog`.
+Sometimes messages of type `post` are not enough for you to express what you need. All messages in Secure Scuttlebutt have a maximum size of 8k which is counting the metadata associated with the message and not just the content itself. For those occasions when you need to write longer messages you can use `blog`.
 
-These messages are actually a small set of metadata, just enough so that clients can display a summary and an associated [blob (this link explains them in deep)](https://ssbc.github.io/scuttlebutt-protocol-guide/#blobs) which holds the content. 
+These messages are actually a small set of metadata, just enough so that clients can display a summary and an associated [blob (this link explains them in depth)](https://ssbc.github.io/scuttlebutt-protocol-guide/#blobs) which holds the content. 
 
-> **Attention:** Patchfox currenytly **supports reading blogposts but does't support writing them.** This will change once I figure out how to do blob uploading.
+> **Attention:** Patchfox currently **supports reading blogposts but does't support writing them.** This will change once I figure out how to do blob uploading.
 
-> **About blobs:** You can think of blobs like attachments to an email. Blobs are not downloaded automatically, they need to be requested. Patchfox will request images on its own so that you can see posts and images together but it will not requests other blobs unless you initiate some action that needs them. In cases such as `blog` messages, the blobs are requested when you press the _Read Blogpost_ button. If you don't press it, we don't download that post.
+> **About blobs:** You can think of blobs like attachments to an email. Blobs are not downloaded automatically, they need to be requested. Patchfox will request images on its own so that you can see posts and images together but it will not request other blobs unless you initiate some action that needs them. In cases such as `blog` messages, the blobs are requested when you press the _Read Blogpost_ button. If you don't press it, we don't download that post.
 
-## What blog posts look like?
+## What do blog posts look like?
 
 ~~~~
 {

--- a/docs/message_types/channel.md
+++ b/docs/message_types/channel.md
@@ -3,7 +3,7 @@ This message is used to _subscribe and unsubscribe from channels_. Be aware that
 
 > **Important:** At the moment Patchfox ignores this information. In the future we plan to change the public view to take this into account.
 
-## How does it looks like?
+## What does it looks like?
 
 ~~~
 {

--- a/docs/message_types/contact.md
+++ b/docs/message_types/contact.md
@@ -1,7 +1,7 @@
 # contact
-Contact messages are used to follow or unfollow another user. This affects your social graph and gossiping. Once you follow a given user, you'll start replicating all that user feed and depending on how your client is configured you will also replicate their friends. Most clients will do two levels of replication, so you end up with all your friends data and friends of friends data, much like the physical world in which you receive gossip regarding your friends friends.
+Contact messages are used to follow or unfollow another user. This affects your social graph and gossiping. Once you follow a given user, you'll start replicating all of that user's feed and, depending on how your client is configured, their friends. Most clients will do two levels of replication, so you end up with all your friends' data and friends-of-friends' data, much like the physical world in which you receive gossip regarding your friends' friends.
 
-## How does it look like?
+## What does it look like?
 
 ~~~
 {

--- a/docs/message_types/post.md
+++ b/docs/message_types/post.md
@@ -1,9 +1,9 @@
 # post
-Post messages are text-based messages intented to a public or private audience. They are what you normally see on feeds from social networks and make most of the meaningful interaction in Scuttlebutt at the moment.
+Post messages are text-based messages intended for a public or private audience. They are what you normally see on feeds from social networks and make most of the meaningful interaction in Scuttlebutt at the moment.
 
 > **Attention:** Patchfox currently doesn't support private messages.
 
-## How does it looks like?
+## What does it look like? 
 
 ~~~
 {
@@ -35,6 +35,6 @@ These messages have a lot of fields. Lets go through the most important ones:
 * `branch`: If this message is a reply to another message, then `branch` points at the message this message is replying to.
 * `channel`: The channel this message is being posted to. It works much like hashtags but don't need to be present in the content itself.
 
-There are other fields such as `recps` which holds the recipients for the messages and is used by private messages and `mentions` which is used to help link mentioned users and messages.
+There are other fields such as `recps`- which holds the recipients for the messages and is used by private messages- and `mentions`- which is used to help link mentioned users and messages.
 
 There is [more information about posts online](http://scuttlebot.io/docs/message-types/post.html).

--- a/docs/message_types/vote.md
+++ b/docs/message_types/vote.md
@@ -1,7 +1,7 @@
 # vote
 This message is akin to _likes_, _hearts_ and _stars_ in social networks. They represent an intention to support the message. Secure Scuttlebutt doesn't mandate a term to be used in this case and some clients will call it _like_ while others call it _dig_, it doesn't matter, the message structure is the same.
 
-## How does it looks like?
+## What does it looks like?
 
 ~~~
 {
@@ -30,4 +30,4 @@ This message is akin to _likes_, _hearts_ and _stars_ in social networks. They r
 
 On the message above you can see that the author is doing a _Like_ (as specified by the `expression` field) towards a message specified by the `link` field. The value `1` means a positive outcome, a value `-1` means withdrawing your positive vote from the message.
 
-There is [more information about `vote` message](http://scuttlebot.io/docs/message-types/vote.html) available online.
+There is [more information about the `vote` message](http://scuttlebot.io/docs/message-types/vote.html) available online.


### PR DESCRIPTION
this is a set of relatively minor doc revisions, mostly correcting small typos.  The biggest change I did was adjust the schema heading  from 'How does it look like?' to 'What does it look like?', as the latter felt more readable.