### PR TITLE
Use {name}, rather than {feed}, for alt text.

### DIFF
--- a/src/ui/messageTypes/MessageRenderer.svelte
+++ b/src/ui/messageTypes/MessageRenderer.svelte
@@ -133,7 +133,7 @@
         <div class="tile tile-centered feed-display" on:click={goProfile}>
           <div class="tile-icon">
             <div class="example-tile-icon">
-              <img src={image} class="avatar avatar-lg" alt={feed} />
+              <img src={image} class="avatar avatar-lg" alt={name} />
             </div>
           </div>
           <div class="tile-content">


### PR DESCRIPTION
As a screen reader user, the previous behavior is spammy because it reads the key contents to me rather than the poster's profile name. This makes the experience of reading my feed far more pleasant. It looks like {feed} is the fallback, so I don't think this should break anything.