### PR TITLE
remove manifest from config system (fixes #69)

### DIFF
--- a/src/core/kernel/prefs.js
+++ b/src/core/kernel/prefs.js
@@ -32,10 +32,9 @@ const getPref = (key, defaultValue) => {
 }
 
 
-const setConnectionConfiguration = ({ keys, remote, manifest }) => {
+const setConnectionConfiguration = ({ keys, remote }) => {
     savedData.keys = keys
     savedData.remote = remote
-    savedData.manifest = manifest
 
     browser.storage.local.set(savedData)
 

--- a/src/packages/settings/IdentityAndConnection.svelte
+++ b/src/packages/settings/IdentityAndConnection.svelte
@@ -9,7 +9,7 @@
     document.title = "Patchfox - Settings - Identity And Connection";
 
     const saveConfiguration = ev => {
-        setConnectionConfiguration({remote, keys: JSON.parse(keys), manifest});
+        setConnectionConfiguration({remote, keys: JSON.parse(keys)});
         location.reload();
     };
 


### PR DESCRIPTION
It seems like this was just a left-over since there also is a copy of this file in `./src/core/platforms/ssb/manifest.js`