### PR TITLE
Add a second newline to separate paragraphs

### DIFF
--- a/src/core/background/contextMenus.js
+++ b/src/core/background/contextMenus.js
@@ -47,7 +47,7 @@ function initializeContextMenus() {
         console.dir("info", info)
         switch (info.menuItemId) {
             case "text-selection-to-clipboard-as-quotation":
-                template = `> ${info.selectionText}\n&mdash; _Source: [${tab.title}](${info.pageUrl})_`
+                template = `> ${info.selectionText}\n\n&mdash; _Source: [${tab.title}](${info.pageUrl})_`
                 copyToClipboard(template, template)
                 break;
             case "page-action-to-clipboard-as-link":


### PR DESCRIPTION
Problem: In SSB-Flavored Markdownt the newline character just does a `<br>` instead of adding text outside of the paragraph, and in most Markdown variants this has no effect (and just appends to the previous sentence).

Solution: Use two newlines to get a paragraph break instead of a single linebreak.