### PR TITLE
Link username to profile in follow, vote and subscribe messages

### DIFF
--- a/src/packages/contacts/ContactCard.svelte
+++ b/src/packages/contacts/ContactCard.svelte
@@ -25,10 +25,17 @@
     ev.preventDefault();
     patchfox.go("contacts", "profile", { feed: msg.value.content.contact });
   };
+
+  const avatarClick = ev => {
+    let feed = ev.detail.feed;
+    patchfox.go("contacts", "profile", { feed });
+  };
+
 </script>
 
 <p class="m-2">
-  <AvatarChip feed={msg.value.author} /> {verb}
+  <AvatarChip feed={msg.value.author} on:avatarClick={avatarClick} />
+  {verb}
   <a
     href="?pkg=contacts&view=profile&feed={otherPersonFeed}"
     on:click={goProfile}>

--- a/src/packages/hub/ChannelCard.svelte
+++ b/src/packages/hub/ChannelCard.svelte
@@ -14,10 +14,16 @@
     ev.preventDefault();
     patchfox.go("hub", "channel", { channel: msg.value.content.channel });
   };
+
+  const avatarClick = ev => {
+    let feed = ev.detail.feed;
+    patchfox.go("contacts", "profile", { feed });
+  };
+
 </script>
 
 <p class="m-2">
-  <AvatarChip feed={msg.value.author} />
+  <AvatarChip feed={msg.value.author} on:avatarClick={avatarClick} />
   {verb}
   <a href="?pkg=hub&view=channel&channel={channel}" on:click={goChannel}>
     #{channel}

--- a/src/packages/vote/Vote.svelte
+++ b/src/packages/vote/Vote.svelte
@@ -34,10 +34,17 @@
       patchfox.go("hub", "thread", { thread: msgid });
     }
   };
+
+  const avatarClick = ev => {
+    let feed = ev.detail.feed;
+    patchfox.go("contacts", "profile", { feed });
+  };
+
 </script>
 
 <p class="m-2">
-  <AvatarChip feed={msg.value.author} /> {expression}
+  <AvatarChip feed={msg.value.author} on:avatarClick={avatarClick} />
+  {expression}
   <a href="?pkg=hub&view=thread&thread={encodedid}" on:click={goThread}>
     {label}
   </a>


### PR DESCRIPTION
Clicking the username/AvatarChip in a follow/unfollow, vote or subscribe/unsubscribe message does not open the user's profile page. I would have expected that behaviour, as the AvatarChip looks like a link and that's the behaviour in the follower list.

These changes solve the issue on my machine. It might make more sense to put the logic in core/components/AvatarChip.svelte. AvatarChip also lacks on:click in books/BookCard and calendar/GatheringActionCard, but I haven't used those features.