### PR TITLE
[[ contacts ]] better contact rendering

### DIFF
--- a/src/core/components/AvatarChip.svelte
+++ b/src/core/components/AvatarChip.svelte
@@ -25,7 +25,11 @@
     cursor: pointer;
   }
 
-  .fix {
+  .fix-a {
+    margin-bottom: 8px;
+    max-width: unset;
+  }
+  .fix-img {
     object-fit: cover;
   }
 </style>
@@ -33,15 +37,19 @@
 {#if image}
   <a
     href={patchfox.url('contacts', 'profile', { feed })}
-    class="chip clickable"
+    class="chip clickable d-flex text-ellipsis fix-a"
+    title={name}
+    aria-label={name}
     on:click|preventDefault|stopPropagation={avatarClick}>
-    <img src={image} class="fix avatar avatar-sm" alt={name} />
+    <img src={image} class="fix-img avatar avatar-sm" alt={name} />
     {name}
   </a>
-{:else}
+  {:else}
   <a
     href={patchfox.url('contacts', 'profile', { feed })}
-    class="chip clickable"
+    class="chip clickable d-flex text-ellipsis fix-a"
+    title={name}
+    aria-label={name}
     on:click|preventDefault|stopPropagation={avatarClick}>
     {name}
   </a>

--- a/src/core/components/AvatarContainer.svelte
+++ b/src/core/components/AvatarContainer.svelte
@@ -1,0 +1,9 @@
+<style>
+  .fix {
+    columns: 3 200px;
+  }
+</style>
+
+<div class="fix" on:click>
+  <slot />
+</div>

--- a/src/packages/contacts/Followers.svelte
+++ b/src/packages/contacts/Followers.svelte
@@ -1,6 +1,7 @@
 <script>
   const QueryRepeater = require("../../core/components/QueryRepeater.svelte");
   const AvatarChip = require("../../core/components/AvatarChip.svelte");
+  const AvatarContainer = require("../../core/components/AvatarContainer.svelte");
   const pull = require("pull-stream");
   const Abortable = require("pull-abortable");
   const _ = require("lodash");
@@ -56,9 +57,11 @@
   patchfox.listen("package:activate:contacts:profile", () => location.reload());
 </script>
 
-{#each contacts as contact}
-  <AvatarChip feed={contact} on:avatarClick={avatarClick} />
-{/each}
+<AvatarContainer>
+  {#each contacts as contact}
+    <AvatarChip feed={contact} on:avatarClick={avatarClick} />
+  {/each}
+</AvatarContainer>
 {#if loading}
   <div class="loading" />
 {/if}

--- a/src/packages/contacts/Following.svelte
+++ b/src/packages/contacts/Following.svelte
@@ -1,6 +1,7 @@
 <script>
   const QueryRepeater = require("../../core/components/QueryRepeater.svelte");
   const AvatarChip = require("../../core/components/AvatarChip.svelte");
+  const AvatarContainer = require("../../core/components/AvatarContainer.svelte");
   const pull = require("pull-stream");
   const Abortable = require("pull-abortable");
   const _ = require("lodash");
@@ -56,10 +57,11 @@
 
   patchfox.listen("package:activate:contacts:profile", () => location.reload());
 </script>
-
-{#each contacts as contact}
-  <AvatarChip feed={contact} on:avatarClick={avatarClick} />
-{/each}
+<AvatarContainer>
+  {#each contacts as contact}
+    <AvatarChip feed={contact} on:avatarClick={avatarClick} />
+  {/each}
+</AvatarContainer>
 {#if loading}
   <div class="loading" />
 {/if}

--- a/src/packages/contacts/Friends.svelte
+++ b/src/packages/contacts/Friends.svelte
@@ -1,6 +1,7 @@
 <script>
   const QueryRepeater = require("../../core/components/QueryRepeater.svelte");
   const AvatarChip = require("../../core/components/AvatarChip.svelte");
+  const AvatarContainer = require("../../core/components/AvatarContainer.svelte");
   const pull = require("pull-stream");
   const Abortable = require("pull-abortable");
   const paramap = require("pull-paramap");
@@ -67,9 +68,11 @@
   patchfox.listen("package:activate:contacts:profile", () => location.reload());
 </script>
 
-{#each contacts as contact}
-  <AvatarChip feed={contact} on:avatarClick={avatarClick} />
-{/each}
+<AvatarContainer>
+  {#each contacts as contact}
+    <AvatarChip feed={contact} on:avatarClick={avatarClick} />
+  {/each}
+</AvatarContainer>
 {#if loading}
   <div class="loading" />
 {/if}


### PR DESCRIPTION
Display contact avatars in a more ordered way providing the necessary space to make them more readable.

- Create the **AvatarContainer** component to wrap the avatars inside and display them as columns of minimum `200px` wide.
- Fix the **AvatarChip** component to display the avatar names and pictures correctly (_max-width_, and _display_).
- Use text ellipsis to truncate the avatar names when they are too long to fit correctly in the columns.
- Add `title` and `aria-label` attributes to links to provide a tooltip with the full contact name when this is truncated and provide better context for accessibility tools.

### Before:

<img width="842" alt="before" src="https://user-images.githubusercontent.com/282903/119853046-d5dccf80-bedd-11eb-9500-f359b124db74.png">

### After:

<img width="842" alt="after" src="https://user-images.githubusercontent.com/282903/119853670-674c4180-bede-11eb-910a-df5a39d82167.png">

Note: the full file changes in _Followers.svelte_, _Following.svelte_, and _Friends.svelte_ are related to the line break differences between Windows and UNIX.