### PR TITLE
copy package doc edits to the correct folders

### DIFF
--- a/scripts/copy-package-docs.js
+++ b/scripts/copy-package-docs.js
@@ -53,8 +53,8 @@ These are the packages that Patchfox is loading.
       if (readme.indexOf("## Source code") == -1) {
         fs.appendFileSync(packageReadme, `
 ## Source code
-* [View package \`${packageName}\` at Github](https://github.com/soapdog/patchfox/blob/master/src/packages/${packageName}) 
-* [View package \`${packageName}\` at Sourcehut](https://git.sr.ht/~soapdog/patchfox/tree/master/item/src/packages/${packageName})
+* [View package \`${packageName}\` at GitHub](https://github.com/soapdog/patchfox/blob/master/src/packages/${packageName}) 
+* [View package \`${packageName}\` at SourceHut](https://git.sr.ht/~soapdog/patchfox/tree/master/item/src/packages/${packageName})
 `)
       }
       fs.appendFileSync("dist/docs/packages/README.md", `* [${elems[2]}](/packages/${elems[2]}/)\n`)

--- a/src/packages/blog/docs/README.md
+++ b/src/packages/blog/docs/README.md
@@ -2,6 +2,6 @@
 
 This package provides the following features:
 
-* Reading messages of type `blog`.
-* Composing messages of type `blog`.
-* A mini-app called `Blog` which is available from the _Launcher_ and helps with importing RSS/Atom feeds.
+* Reading messages of type `blog`
+* Composing messages of type `blog`
+* A mini-app called `Blog` which is available from the _Launcher_ and can import RSS/Atom feeds

--- a/src/packages/books/docs/README.md
+++ b/src/packages/books/docs/README.md
@@ -1,5 +1,3 @@
 # Books Package
 
-Books is a mini-app that provides _book club_ features to SSB similar to _Goodreads_ and _The StoryGraph_. You can add and edit books and reviews.
-
-
+Books is a mini-app that provides _book club_ features to SSB similar to _Goodreads_ and _The StoryGraph_. You can add and edit books, and leave reviews for them.

--- a/src/packages/calendar/docs/README.md
+++ b/src/packages/calendar/docs/README.md
@@ -1,10 +1,9 @@
 # Calendar Package
 
-The Calendar package provides support for messages of type _gathering_ which is how SSB deals with events.
+The `calendar` package provides support for messages of type `gathering`, which is the SSB identifier for events.
 
 ## Features
-* A card that displays events on your various timeline views.
-* A view to display details about a given gathering.
-* A menu entry to export a gathering as an iCalendar file.
-* A view to see future events.
-
+* A card that displays events in various timeline views
+* A view to display details about a given gathering
+* A menu entry to export a gathering as an iCalendar file
+* A view to see future events

--- a/src/packages/contacts/docs/README.md
+++ b/src/packages/contacts/docs/README.md
@@ -1,11 +1,10 @@
 # Contacts Package
 
-The Contacts package is responsible for dealing with all related contact/feed features.
+The `contacts` package is responsible for dealing with all contact/feed-related features.
 
 ## Features
-* A card that displays information when someone alters a profile.
-* A view to display profiles.
-* A view to edit your own profiles.
-* A feature to add **private** address-book-like information to any profile (this is called More Info).
-* View the list of followers, following, and blocks, for profiles.
-
+* A card that displays information when someone updates a profile
+* A view to display profiles
+* A view to edit your own profiles
+* A feature to add **private** address-book-like information to any profile (this is called More Info)
+* View a profile's list of followers, who they are following, and their blocks

--- a/src/packages/errorHandler/docs/README.md
+++ b/src/packages/errorHandler/docs/README.md
@@ -1,7 +1,7 @@
 # errorHandler Package
 
-The errorHandler package is a neat package that presents a nice interface when something breaks in Patchfox.
+The `errorHandler` package presents a nice interface when something breaks in Patchfox.
 
 ## Features
-* Prevents catastrophic errors from failing silent.
-* Gives a hint to where to look in the source.
+* Prevents catastrophic errors from failing silently
+* Hints at where to look in the source

--- a/src/packages/githubIntegration/docs/README.md
+++ b/src/packages/githubIntegration/docs/README.md
@@ -1,3 +1,3 @@
 # githubIntegration Package
 
-The githubIntegration package adds menu entries to check the source on github.
+The `githubIntegration` package adds menu entries to check the source on GitHub.

--- a/src/packages/globalMenu/docs/README.md
+++ b/src/packages/globalMenu/docs/README.md
@@ -1,3 +1,3 @@
 # globalMenu Package
 
-The globalMenu package manages the menu at the top of the Patchfox interface.
+The `globalMenu` package manages the menu at the top of the Patchfox interface.

--- a/src/packages/helpMenu/docs/README.md
+++ b/src/packages/helpMenu/docs/README.md
@@ -1,3 +1,3 @@
 # helpMenu Package
 
-The helpMenu package assembles the help menu.
+The `helpMenu` package assembles the help menu.

--- a/src/packages/hub/docs/README.md
+++ b/src/packages/hub/docs/README.md
@@ -1,6 +1,6 @@
 # Hub Package
 
-The Hub package is the largest package on Patchfox and the main package the users interact on a daily basis. It provides all the following views:
+The `hub` is the largest package in Patchfox and the main one that users interact with on a daily basis. It provides all the following views:
 
 * Public
 * Channel
@@ -8,4 +8,3 @@ The Hub package is the largest package on Patchfox and the main package the user
 * Popular
 * Thread
 * ChannelCard
-

--- a/src/packages/intercept/docs/README.md
+++ b/src/packages/intercept/docs/README.md
@@ -1,3 +1,3 @@
 # Intercept Package
 
-The intercept package manages the `ssb:` custom URL schema handling.
+The `intercept` package manages the `ssb:` custom URL schema handling.

--- a/src/packages/launcher/docs/README.md
+++ b/src/packages/launcher/docs/README.md
@@ -1,3 +1,3 @@
 # Launcher Package
 
-The _Launcher_ that is accessible on the _Patchfox Menu_ or by pressing _CTRL+M_. Gives access to the mini-apps.
+The _Launcher_ is accessible on the _Patchfox Menu_ or by pressing _CTRL+M_. When activated, it provides access to the mini-apps.

--- a/src/packages/openCollectiveIntegration/docs/README.md
+++ b/src/packages/openCollectiveIntegration/docs/README.md
@@ -1,3 +1,3 @@
 # openCollectiveIntegration Package
 
-The openCollectiveIntegration package adds menu entries related to the [Patchfox Open Collective](https://opencollective.com/patchfox).
+The `openCollectiveIntegration` package adds menu entries related to the [Patchfox Open Collective](https://opencollective.com/patchfox).

--- a/src/packages/post/docs/README.md
+++ b/src/packages/post/docs/README.md
@@ -1,9 +1,9 @@
 # Post Package
 
-The Post package manages handling of messages of type `post` which are the most common messages on SSB.
+The `post` package handles messages of type [`post`](https://scuttlebot.io/docs/message-types/post.html), which is the most common type on SSB.
 
 ## Features
 
-* PostCard for displaying post messages on various views.
-* PostCompose view for making new posts.
-* Menu entry on _Compose_ menu.
+* PostCard for displaying post messages on various views
+* PostCompose view for making new posts
+* Menu entry on _Compose_ menu

--- a/src/packages/private/docs/README.md
+++ b/src/packages/private/docs/README.md
@@ -1,3 +1,3 @@
 # Private Package
 
-This is a stub package to display a padlock message card when a private message is rendered in the various QueryRepeater views. Will eventually be replaced by a proper private messaging package.
+This is a stub package that displays a padlock message card when a private message is rendered in the various QueryRepeater views. It will eventually be replaced by a proper private messaging package.

--- a/src/packages/pub/docs/README.md
+++ b/src/packages/pub/docs/README.md
@@ -1,3 +1,3 @@
 # Pub Package
 
-The Pub package handles displaying _pub announcements_.
+The `pub` package handles displaying [pub announcements](https://scuttlebot.io/docs/message-types/pub.html).

--- a/src/packages/search/docs/README.md
+++ b/src/packages/search/docs/README.md
@@ -1,3 +1,3 @@
 # Search Package
 
-The Search package manages searching on SSB. Which can happen by either using the search box on top of the interface or `ssb?` in the omnibox.
+The `search` package manages searching on SSB. Users can search either by using the search box on top of the interface, or by typing `ssb?` in the browser's omnibox.

--- a/src/packages/settings/docs/README.md
+++ b/src/packages/settings/docs/README.md
@@ -1,3 +1,5 @@
 # Settings Package
 
-The Settings Package is a large one and deals with all the settings on the add-on. Most importantly it is in this package that the feed secret is configured.
+The `settings` package handles all of Patchfox's settings.
+
+Most importantly, it is in this package that the feed secret is configured.

--- a/src/packages/sourcehutIntegration/docs/README.md
+++ b/src/packages/sourcehutIntegration/docs/README.md
@@ -1,3 +1,3 @@
 # sourcehutIntegration Package
 
-The sourcehutIntegration package adds menu entries to check the source on sourcehut.
+The `sourcehutIntegration` package adds menu entries to check the source on SourceHut.

--- a/src/packages/system/docs/README.md
+++ b/src/packages/system/docs/README.md
@@ -1,9 +1,9 @@
 # System Package
 
-The System package is kind of a catch-all package that adds a _system menu_ to the _Patchfox menu_.
+The `system` package adds a _system menu_ to the _Patchfox menu_.
 
 ## Features
 
-* Joining pubs.
-* Seeing the indexing status.
-* Seeing the peer list.
+* Joining pubs
+* Seeing the indexing status
+* Seeing the peer list

--- a/src/packages/vote/docs/README.md
+++ b/src/packages/vote/docs/README.md
@@ -1,7 +1,7 @@
 # Vote Package
 
-The Vote package manages handling of messages of type `vote` which are quite common messages on SSB. They are what happens when you _like_ or _heart_ a post.
+The `vote` package handles [`vote` messages](https://scuttlebot.io/docs/message-types/vote.html), which are quite common on SSB. They are created when you _like_ or _heart_ a post.
 
 ## Features
 
-* VoteCard to display liking or hearting actions.
+* VoteCard to display liking or hearting actions


### PR DESCRIPTION
Should fix this issue: https://github.com/soapdog/patchfox/pull/126#issuecomment-945762695

I did a test run with the copy scripts and the resulting files matched the ones from my previous PR so I think it's all in the right place now.